### PR TITLE
Dockerのappコンテナの同期先を修正

### DIFF
--- a/part2/Dockerfile
+++ b/part2/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 # ファイルのコピー
-COPY ./ /var/www/html
+COPY ./src /var/www/html
 COPY ./docker/app/php.ini /usr/local/etc/php/php.ini
 
 # Heroku で Apache2 が設定エラーになることへの対応

--- a/part2/docker/app/Dockerfile
+++ b/part2/docker/app/Dockerfile
@@ -12,5 +12,5 @@ COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 # ファイルのコピー
-COPY ./ /var/www/html
+COPY ./src /var/www/html
 COPY ./docker/app/php.ini /usr/local/etc/php/php.ini


### PR DESCRIPTION
srcディレクトリ以下しかDockerコンテナに同期する必要ないので修正（Herokuのエラー対策も兼ねる）